### PR TITLE
Fix generate (rtk_lef, lib) scripts with more recent open_pdks/volare builds

### DIFF
--- a/generate_lib/generate_lib.sh
+++ b/generate_lib/generate_lib.sh
@@ -44,9 +44,6 @@ sed -i '82988 a \
             voltage_name : "VNB";\
         }' $lib_file
 
-# Remove sparecell
-sed -i '83101, 83135d' $lib_file
-
 lc_shell -f lc_shell_gen_lib.tcl
 
 cp $lib_file $TOP/generate_db

--- a/generate_lib/generate_lib.sh
+++ b/generate_lib/generate_lib.sh
@@ -6,17 +6,6 @@ export lib_file=$TOP/generate_lib/sky130_fd_sc_hd__tt_025C_1v80.lib
 # cp $SKYWATER130_HOME/libs.ref/sky130_fd_sc_hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib $lib_file
 python $TOP/generate_lib/generate_lib.py
 
-# Hotfix for issue #288
-# Swap related_bias_pin VPB and VNB
-sed -i 's/related_bias_pin : "VPB";/related_bias_pin : "VNBTEMP";/g' $lib_file
-sed -i 's/related_bias_pin : "VNB";/related_bias_pin : "VPB";/g' $lib_file
-sed -i 's/related_bias_pin : "VNBTEMP";/related_bias_pin : "VNB";/g' $lib_file
-
-# Swap pg_type nwell and pwell
-sed -i 's/pg_type : "nwell";/pg_type : "pwelltemp";/g' $lib_file
-sed -i 's/pg_type : "pwell";/pg_type : "nwell";/g' $lib_file
-sed -i 's/pg_type : "pwelltemp";/pg_type : "pwell";/g' $lib_file
-
 # Hotfix for issue #183
 sed -i '82150 a \
         pg_pin ("VNB") {\

--- a/generate_lib/generate_lib.sh
+++ b/generate_lib/generate_lib.sh
@@ -6,43 +6,35 @@ export lib_file=$TOP/generate_lib/sky130_fd_sc_hd__tt_025C_1v80.lib
 # cp $SKYWATER130_HOME/libs.ref/sky130_fd_sc_hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib $lib_file
 python $TOP/generate_lib/generate_lib.py
 
-# Hotfix for issue #183
-sed -i '82150 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
-sed -i '82289 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
-sed -i '82428 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
-sed -i '82710 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
-sed -i '82849 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
-sed -i '82988 a \
-        pg_pin ("VNB") {\
-            pg_type : "pwell";\
-            physical_connection : "device_layer";\
-            voltage_name : "VNB";\
-        }' $lib_file
+process_lib() {
+    # Hotfix for issue #183
+    lines=$(grep -n 'sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap' $1 | cut -f1 -d:)
+    offset=0
+    for line in $lines; do
+        line=$(($line + 22 + offset))
+        sed -i "$line a \\
+        pg_pin (\"VNB\") {\\
+            pg_type : \"pwell\";\\
+            physical_connection : \"device_layer\";\\
+            voltage_name : \"VNB\";\\
+        }" $1
+        offset=$(($offset + 5))
+    done
+    offset=0
+    lines=$(grep -n 'sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap' $1 | cut -f1 -d:)
+    for line in $lines; do
+        line=$(($line + 26 + offset))
+        sed -i "$line a \\
+        pg_pin (\"VNB\") {\\
+            pg_type : \"pwell\";\\
+            physical_connection : \"device_layer\";\\
+            voltage_name : \"VNB\";\\
+        }" $1
+        offset=$(($offset + 5))
+    done
+}
+
+process_lib $lib_file
 
 lc_shell -f lc_shell_gen_lib.tcl
 

--- a/generate_rtk_lef/generate_rtk_lef.py
+++ b/generate_rtk_lef/generate_rtk_lef.py
@@ -3,4 +3,4 @@ import os
 
 SKYWATER130_HOME = os.environ['SKYWATER130_HOME']
 TOP = os.environ['TOP']
-copyfile(SKYWATER130_HOME + '/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd.tlef', TOP + '/view-standard/rtk-tech.lef')
+copyfile(SKYWATER130_HOME + '/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd__nom.tlef', TOP + '/view-standard/rtk-tech.lef')

--- a/generate_rtk_lef/generate_rtk_lef.sh
+++ b/generate_rtk_lef/generate_rtk_lef.sh
@@ -2,7 +2,7 @@
 # Author: Charles Tsao
 
 # Generate LEF
-cp $SKYWATER130_HOME/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd.tlef \
+cp $SKYWATER130_HOME/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd__nom.tlef \
     $TOP/view-standard/rtk-tech.lef
 
 # Edit LEF per issue #308 and #312


### PR DESCRIPTION
Resolves #1.

This updates some generate scripts to work with newer builds from open_pdks/volare. Didn't encounter an assertion error about sparecell, so I opted to remove it. Please let me know if this is still needed as I plan to support additional corners (https://github.com/hansemro/skywater-130nm/tree/ff_ss_corners_rebuild).

Tested with:
- mflowgen against GcdUnit design from https://code.stanford.edu/ee272/skywater-digital-flow
- volare sky130 build e6f9c8876da77220403014b116761b0b2d79aab4 (2023.02.10)